### PR TITLE
Add SPTVRAMCleaner as an invalid plugin

### DIFF
--- a/Fika.Headless/FikaHeadlessPlugin.cs
+++ b/Fika.Headless/FikaHeadlessPlugin.cs
@@ -390,7 +390,8 @@ namespace Fika.Headless
                 "com.mpstark.DynamicMaps",
                 "IhanaMies.LootValue",
                 "com.cactuspie.ramcleanerinterval",
-                "com.TYR.DeClutter"
+                "com.TYR.DeClutter",
+                "SPTVRAMCleaner.UniqueGUID"
             ];
             PluginInfo[] pluginInfos = [.. Chainloader.PluginInfos.Values];
             List<string> unsupportedMods = [];


### PR DESCRIPTION
SPTVRAMCleaner has been proven to consistently crash the headless client when it activates. This will add it to the list of banned plugins.